### PR TITLE
feat: Add OVS flow check setup and cleanup automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ artifacts/
 scan-image.sh
 build-and-publish.sh
 requirements.old.txt
+backend/control_center/env/extravars
+backend/control_center/utils/env/extravars

--- a/backend/control_center/ansible/playbooks/ovs-cleanup-flow-check.yml
+++ b/backend/control_center/ansible/playbooks/ovs-cleanup-flow-check.yml
@@ -1,0 +1,7 @@
+---
+- name: Cleanup OVS Flow Check
+  hosts: localserver
+  gather_facts: yes
+  become: true
+  roles:
+    - ../roles/ovs-cleanup-flow-check

--- a/backend/control_center/ansible/playbooks/ovs-setup-flow-check.yml
+++ b/backend/control_center/ansible/playbooks/ovs-setup-flow-check.yml
@@ -1,0 +1,7 @@
+---
+- name: Set up OVS flow check
+  hosts: localserver
+  gather_facts: yes
+  become: true
+  roles:
+    - ../roles/ovs-flow-check

--- a/backend/control_center/ansible/playbooks/resources/ovs-flow-check/check_ovs_flows.sh
+++ b/backend/control_center/ansible/playbooks/resources/ovs-flow-check/check_ovs_flows.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# /usr/local/bin/check_ovs_flows.sh - Ensure essential OVS flows are always present
+
+# Get bridge name from first argument
+BRIDGE="${1}"
+if [ -z "${BRIDGE}" ]; then
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - ERROR: Bridge name is required as first argument" >&2
+    exit 1
+fi
+
+LOG_FILE="/var/log/ovs_flow_check_${BRIDGE}.log"
+
+# Function to write log messages with a timestamp
+log_message() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" >> "${LOG_FILE}" 2>&1
+}
+
+log_message "--- Starting OVS flow verification for bridge '${BRIDGE}' ---"
+
+# --- Define the flows we need to ensure exist ---
+# We use cookies as unique identifiers for each flow.
+# Flow 1: ARP Handler
+FLOW_ARP_COOKIE="0x1000"
+FLOW_ARP_RULE="cookie=${FLOW_ARP_COOKIE},priority=100,arp,actions=NORMAL"
+
+# Flow 2: Default Forwarding
+FLOW_DEFAULT_COOKIE="0x1001"
+FLOW_DEFAULT_RULE="cookie=${FLOW_DEFAULT_COOKIE},priority=1,actions=NORMAL"
+
+# Flow 3: Send to Controller (miss rule)
+FLOW_CONTROLLER_COOKIE="0xa"
+FLOW_CONTROLLER_RULE="cookie=${FLOW_CONTROLLER_COOKIE},priority=0,actions=CONTROLLER:65535"
+
+# --- Check and Add Logic ---
+# Use a single `dump-flows` call for efficiency
+CURRENT_FLOWS=$(sudo ovs-ofctl dump-flows ${BRIDGE} -OOpenflow13 2>> "${LOG_FILE}")
+
+# Check for ARP flow
+if ! echo "${CURRENT_FLOWS}" | grep -q "cookie=${FLOW_ARP_COOKIE}"; then
+    log_message "ARP flow (cookie ${FLOW_ARP_COOKIE}) is MISSING. Re-adding..."
+    sudo ovs-ofctl add-flow ${BRIDGE} "${FLOW_ARP_RULE}" -OOpenflow13 >> "${LOG_FILE}" 2>&1
+    if [ $? -eq 0 ]; then
+        log_message "ARP flow (cookie ${FLOW_ARP_COOKIE}) successfully re-added."
+    else
+        log_message "ERROR: Failed to re-add ARP flow (cookie ${FLOW_ARP_COOKIE})."
+    fi
+else
+    log_message "ARP flow (cookie ${FLOW_ARP_COOKIE}) is present."
+fi
+
+# Check for Default Forwarding flow
+if ! echo "${CURRENT_FLOWS}" | grep -q "cookie=${FLOW_DEFAULT_COOKIE}"; then
+    log_message "Default flow (cookie ${FLOW_DEFAULT_COOKIE}) is MISSING. Re-adding..."
+    sudo ovs-ofctl add-flow ${BRIDGE} "${FLOW_DEFAULT_RULE}" -OOpenflow13 >> "${LOG_FILE}" 2>&1
+    if [ $? -eq 0 ]; then
+        log_message "Default flow (cookie ${FLOW_DEFAULT_COOKIE}) successfully re-added."
+    else
+        log_message "ERROR: Failed to re-add Default flow (cookie ${FLOW_DEFAULT_COOKIE})."
+    fi
+else
+    log_message "Default flow (cookie ${FLOW_DEFAULT_COOKIE}) is present."
+fi
+
+# Check for Send to Controller flow
+if ! echo "${CURRENT_FLOWS}" | grep -q "cookie=${FLOW_CONTROLLER_COOKIE}"; then
+    log_message "Controller miss flow (cookie ${FLOW_CONTROLLER_COOKIE}) is MISSING. Re-adding..."
+    sudo ovs-ofctl add-flow ${BRIDGE} "${FLOW_CONTROLLER_RULE}" -OOpenflow13 >> "${LOG_FILE}" 2>&1
+    if [ $? -eq 0 ]; then
+        log_message "Controller miss flow (cookie ${FLOW_CONTROLLER_COOKIE}) successfully re-added."
+    else
+        log_message "ERROR: Failed to re-add Controller miss flow (cookie ${FLOW_CONTROLLER_COOKIE})."
+    fi
+else
+    log_message "Controller miss flow (cookie ${FLOW_CONTROLLER_COOKIE}) is present."
+fi
+
+log_message "--- OVS flow verification complete ---"
+

--- a/backend/control_center/ansible/roles/ovs-cleanup-flow-check/tasks/cleanup_flow_check.yml
+++ b/backend/control_center/ansible/roles/ovs-cleanup-flow-check/tasks/cleanup_flow_check.yml
@@ -1,0 +1,57 @@
+---
+# Stop and disable the systemd timer for flow check
+- name: Stop and disable OVS Flow Check timer
+  ansible.builtin.systemd:
+    name: "ovs-flow-check-{{ bridge_name }}.timer"
+    state: stopped
+    enabled: no
+  ignore_errors: yes
+
+# Stop and disable the systemd service for flow check
+- name: Stop and disable OVS Flow Check service
+  ansible.builtin.systemd:
+    name: "ovs-flow-check-{{ bridge_name }}.service"
+    state: stopped
+    enabled: no
+  ignore_errors: yes
+
+# Remove the systemd timer file
+- name: Remove systemd timer file for flow check
+  ansible.builtin.file:
+    path: "/etc/systemd/system/ovs-flow-check-{{ bridge_name }}.timer"
+    state: absent
+  ignore_errors: yes
+
+# Remove the systemd service file
+- name: Remove systemd service file for flow check
+  ansible.builtin.file:
+    path: "/etc/systemd/system/ovs-flow-check-{{ bridge_name }}.service"
+    state: absent
+  ignore_errors: yes
+
+# Remove the script from /usr/local/bin
+- name: Remove flow check script
+  ansible.builtin.file:
+    path: "/usr/local/bin/check_ovs_flows_{{ bridge_name }}.sh"
+    state: absent
+  ignore_errors: yes
+
+# Remove the logrotate configuration
+- name: Remove logrotate configuration for flow check
+  ansible.builtin.file:
+    path: "/etc/logrotate.d/ovs-flow-check-{{ bridge_name }}"
+    state: absent
+  ignore_errors: yes
+
+# Remove the log file
+- name: Remove flow check log file
+  ansible.builtin.file:
+    path: "/var/log/ovs_flow_check_{{ bridge_name }}.log"
+    state: absent
+  ignore_errors: yes
+
+# Reload systemd to pick up the removed service and timer
+- name: Reload systemd after removing service and timer
+  ansible.builtin.systemd:
+    daemon_reload: yes
+  ignore_errors: yes

--- a/backend/control_center/ansible/roles/ovs-cleanup-flow-check/tasks/main.yml
+++ b/backend/control_center/ansible/roles/ovs-cleanup-flow-check/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Cleanup OVS Flow Check
+  import_tasks: cleanup_flow_check.yml

--- a/backend/control_center/ansible/roles/ovs-flow-check/tasks/main.yml
+++ b/backend/control_center/ansible/roles/ovs-flow-check/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Setup OVS flow check
+  import_tasks: setup_flow_check.yml

--- a/backend/control_center/ansible/roles/ovs-flow-check/tasks/setup_flow_check.yml
+++ b/backend/control_center/ansible/roles/ovs-flow-check/tasks/setup_flow_check.yml
@@ -1,0 +1,79 @@
+---
+- name: Create log file with correct ownership and permissions
+  ansible.builtin.file:
+    path: "/var/log/ovs_flow_check_{{ bridge_name }}.log"
+    state: touch
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Copy check_ovs_flows.sh script to /usr/local/bin
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/resources/ovs-flow-check/check_ovs_flows.sh"
+    dest: "/usr/local/bin/check_ovs_flows_{{ bridge_name }}.sh"
+    mode: "0755"
+    owner: root
+    group: root
+
+- name: Create systemd service file for OVS flow check
+  ansible.builtin.copy:
+    dest: "/etc/systemd/system/ovs-flow-check-{{ bridge_name }}.service"
+    content: |
+      [Unit]
+      Description=OVS Flow Check for {{ bridge_name }}
+      Documentation=Ensure essential OVS flows are always present on bridge {{ bridge_name }}
+      After=network.target
+
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/local/bin/check_ovs_flows_{{ bridge_name }}.sh {{ bridge_name }}
+      User=root
+      StandardOutput=null
+      StandardError=journal
+
+      [Install]
+      WantedBy=multi-user.target
+    mode: "0644"
+
+- name: Create systemd timer file for OVS flow check
+  ansible.builtin.copy:
+    dest: "/etc/systemd/system/ovs-flow-check-{{ bridge_name }}.timer"
+    content: |
+      [Unit]
+      Description=OVS Flow Check Timer for {{ bridge_name }}
+      Requires=ovs-flow-check-{{ bridge_name }}.service
+
+      [Timer]
+      OnBootSec=360s
+      OnUnitActiveSec=30s
+      Persistent=true
+
+      [Install]
+      WantedBy=timers.target
+    mode: "0644"
+
+- name: Create logrotate configuration for OVS flow check
+  ansible.builtin.copy:
+    dest: "/etc/logrotate.d/ovs-flow-check-{{ bridge_name }}"
+    content: |
+      /var/log/ovs_flow_check_{{ bridge_name }}.log {
+          size 2M
+          rotate 3
+          copytruncate
+          compress
+          delaycompress
+          missingok
+          notifempty
+          create 644 root root
+      }
+    mode: "0644"
+
+- name: Reload systemd to pick up new service and timer files
+  ansible.builtin.systemd:
+    daemon_reload: yes
+
+- name: Enable and start OVS flow check timer
+  ansible.builtin.systemd:
+    name: "ovs-flow-check-{{ bridge_name }}.timer"
+    enabled: yes
+    state: started

--- a/backend/control_center/odl/odl_flow_utils.py
+++ b/backend/control_center/odl/odl_flow_utils.py
@@ -12,7 +12,7 @@ class OdlMeterFlowRule:
                  in_port_of_number_server_to_client, out_port_of_number_server_to_client,
                  client_mac_address, server_mac_address, category_obj_cookie,
                  controller_ip_str, odl_meter_id_numeric, odl_switch_node_id_str,
-                 flow_priority=60000, flow_timeout_seconds=360, table_id=0): # Added table_id
+                 flow_priority=60000, flow_timeout_seconds=90, table_id=0): # Added table_id
 
         self.protocol_str = protocol_str.lower() # 'tcp' or 'udp'
         self.client_port_num = int(client_port_num)


### PR DESCRIPTION
feat: Add OVS flow check setup and cleanup automation

- Introduced new Ansible playbooks for setting up and cleaning up OVS flow checks, ensuring essential flows are maintained.
- Added scripts and systemd service/timer configurations to automate flow verification and management.
- Updated the .gitignore to include new environment variable files and scripts.
- Enhanced the ODL flow utility to adjust flow timeout settings for improved performance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated Open vSwitch flow verification that ensures critical network flows persist on bridges
  * Flow checks run automatically during bridge lifecycle (creation, modification, deletion) with automatic cleanup

* **Chores**
  * Reduced default idle timeout for network flow rules from 360 to 90 seconds

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->