### PR TITLE
feat: enhance dashboard charts with time-range control and metrics

### DIFF
--- a/ui/ui/src/app/dashboard/page.tsx
+++ b/ui/ui/src/app/dashboard/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import NetworkDiagramComponent from "@/components/network/NetworkDiagramComponent";
 import {
   SidebarInset,
@@ -14,10 +15,23 @@ import {
   BreadcrumbList,
 } from "@/components/ui/breadcrumb";
 import { Separator } from "@/components/ui/separator";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useLanguage } from "@/context/languageContext";
+import NetworkThroughputChart from "@/components/dashboard/NetworkThroughputChart";
+import UserActivityChart from "@/components/dashboard/UserActivityChart";
+import DashboardDeviceStats from "@/components/dashboard/DashboardDeviceStats";
+
+type TimeRange = "5min" | "1hour" | "24hour" | "7days";
 
 export default function Dashboard() {
   const { getT } = useLanguage();
+  const [timeRange, setTimeRange] = useState<TimeRange>("1hour");
 
   return (
     <SidebarProvider
@@ -49,7 +63,30 @@ export default function Dashboard() {
           </div>
         </header>
         <div className="@container/main w-full max-w-7.5xl flex flex-col gap-6 px-4 lg:px-8 py-8 mx-auto">
-          {/* If you have multiple dashboard sections, use grid here */}
+          <div className="flex items-center justify-between mb-2">
+            <h2 className="text-lg font-semibold">Network Overview</h2>
+            <div className="flex items-center gap-2">
+              <label className="text-sm text-muted-foreground">Time Range:</label>
+              <Select value={timeRange} onValueChange={(value) => setTimeRange(value as TimeRange)}>
+                <SelectTrigger className="w-[140px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="5min">5 Minutes</SelectItem>
+                  <SelectItem value="1hour">1 Hour</SelectItem>
+                  <SelectItem value="24hour">24 Hours</SelectItem>
+                  <SelectItem value="7days">7 Days</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <NetworkThroughputChart timeRange={timeRange} />
+            <UserActivityChart timeRange={timeRange} />
+            <div className="md:col-span-2">
+              <DashboardDeviceStats />
+            </div>
+          </div>
           <NetworkDiagramComponent />
         </div>
       </SidebarInset>

--- a/ui/ui/src/components/dashboard/DashboardDeviceStats.tsx
+++ b/ui/ui/src/components/dashboard/DashboardDeviceStats.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { useAuth } from "@/context/authContext";
+import { fetchSwitches } from "@/lib/devices";
+import { fetchDeviceStatsAggregate } from "@/lib/deviceStats";
+import { DeviceStatsChart } from "../graphs/device-stats/DeviceStatsChart";
+import { NetworkDeviceDetails, DeviceStatsTimeSeriesPoint } from "@/lib/types";
+import { DeviceStatsSkeleton } from "../graphs/device-stats/DeviceStatsSkeleton";
+
+export default function DashboardDeviceStats() {
+  const { token } = useAuth();
+  const [data, setData] = useState<DeviceStatsTimeSeriesPoint[]>([]);
+  const [device, setDevice] = useState<NetworkDeviceDetails | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!token) return;
+    const load = async () => {
+      try {
+        setLoading(true);
+        // 1. Get first switch
+        const switches = await fetchSwitches(token);
+        console.log("[DashboardDeviceStats] Fetched switches:", switches);
+        
+        // handle paginated or array response
+        let devices: NetworkDeviceDetails[] = [];
+        if (Array.isArray(switches)) {
+          devices = switches;
+        } else if (switches && typeof switches === 'object' && 'results' in switches) {
+          const results = (switches as { results: NetworkDeviceDetails[] }).results;
+          devices = Array.isArray(results) ? results : [];
+        }
+
+        console.log("[DashboardDeviceStats] Found devices:", devices.length);
+
+        if (devices.length === 0) {
+          console.warn("[DashboardDeviceStats] No devices found");
+          setDevice(null);
+          setData([]);
+          return;
+        }
+
+        // Try each device until we find one with stats data
+        let foundDeviceWithData = false;
+        for (const device of devices) {
+          if (!device.lan_ip_address) {
+            console.log("[DashboardDeviceStats] Skipping device without lan_ip_address:", device);
+            continue;
+          }
+
+          console.log("[DashboardDeviceStats] Trying device:", device.lan_ip_address);
+          
+          try {
+            const stats = await fetchDeviceStatsAggregate(
+              token,
+              device.lan_ip_address,
+              1, // 1 hour
+              "1 minute"
+            );
+            
+            console.log(
+              `[DashboardDeviceStats] Stats for ${device.lan_ip_address}:`,
+              stats?.data?.length || 0,
+              "data points"
+            );
+
+            if (stats && stats.data && Array.isArray(stats.data) && stats.data.length > 0) {
+              console.log("[DashboardDeviceStats] Found device with data:", device.lan_ip_address);
+              console.log("[DashboardDeviceStats] Sample data point:", stats.data[0]);
+              setDevice(device);
+              setData(stats.data);
+              foundDeviceWithData = true;
+              break;
+            }
+          } catch (statsError) {
+            console.error(`[DashboardDeviceStats] Error fetching stats for ${device.lan_ip_address}:`, statsError);
+            continue;
+          }
+        }
+
+        if (!foundDeviceWithData) {
+          console.warn("[DashboardDeviceStats] No devices with stats data found");
+          // Still set the first device so we can show which device we checked
+          setDevice(devices[0]);
+          setData([]);
+        }
+      } catch (e) {
+        console.error("Failed to load device stats for dashboard", e);
+        if (e instanceof Error) {
+          console.error("Error details:", e.message, e.stack);
+        }
+        setData([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+    // Refresh every minute like the other charts
+    const interval = setInterval(load, 60000);
+    return () => clearInterval(interval);
+  }, [token]);
+
+  if (loading) {
+    return <DeviceStatsSkeleton />;
+  }
+
+  if (!device) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Device Statistics</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-center min-h-[300px] text-muted-foreground">
+            No monitored devices found.
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Device Statistics</CardTitle>
+        <CardDescription>
+          {device.name || device.lan_ip_address}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {data.length === 0 ? (
+          <div className="flex items-center justify-center min-h-[400px] text-muted-foreground">
+            <div className="text-center">
+              <p>No device statistics data available for the last hour.</p>
+              <p className="text-sm mt-2">
+                Device: {device.lan_ip_address}
+              </p>
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="text-xs text-muted-foreground mb-2">
+              Showing {data.length} data points for {device.lan_ip_address}
+            </div>
+            <DeviceStatsChart data={data} />
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/ui/ui/src/components/dashboard/DashboardDeviceStats.tsx
+++ b/ui/ui/src/components/dashboard/DashboardDeviceStats.tsx
@@ -23,12 +23,13 @@ export default function DashboardDeviceStats() {
 
   useEffect(() => {
     if (!token) return;
+    const abortController = new AbortController();
+    let isMounted = true;
     const load = async () => {
       try {
         setLoading(true);
         // 1. Get first switch
         const switches = await fetchSwitches(token);
-        console.log("[DashboardDeviceStats] Fetched switches:", switches);
         
         // handle paginated or array response
         let devices: NetworkDeviceDetails[] = [];
@@ -39,10 +40,8 @@ export default function DashboardDeviceStats() {
           devices = Array.isArray(results) ? results : [];
         }
 
-        console.log("[DashboardDeviceStats] Found devices:", devices.length);
-
         if (devices.length === 0) {
-          console.warn("[DashboardDeviceStats] No devices found");
+          if (!isMounted) return;
           setDevice(null);
           setData([]);
           return;
@@ -52,60 +51,60 @@ export default function DashboardDeviceStats() {
         let foundDeviceWithData = false;
         for (const device of devices) {
           if (!device.lan_ip_address) {
-            console.log("[DashboardDeviceStats] Skipping device without lan_ip_address:", device);
             continue;
           }
-
-          console.log("[DashboardDeviceStats] Trying device:", device.lan_ip_address);
           
           try {
             const stats = await fetchDeviceStatsAggregate(
               token,
               device.lan_ip_address,
               1, // 1 hour
-              "1 minute"
+              "1 minute",
+              abortController.signal
             );
             
-            console.log(
-              `[DashboardDeviceStats] Stats for ${device.lan_ip_address}:`,
-              stats?.data?.length || 0,
-              "data points"
-            );
-
             if (stats && stats.data && Array.isArray(stats.data) && stats.data.length > 0) {
-              console.log("[DashboardDeviceStats] Found device with data:", device.lan_ip_address);
-              console.log("[DashboardDeviceStats] Sample data point:", stats.data[0]);
+              if (!isMounted) return;
               setDevice(device);
               setData(stats.data);
               foundDeviceWithData = true;
               break;
             }
           } catch (statsError) {
+            if (abortController.signal.aborted) return;
             console.error(`[DashboardDeviceStats] Error fetching stats for ${device.lan_ip_address}:`, statsError);
             continue;
           }
         }
 
         if (!foundDeviceWithData) {
-          console.warn("[DashboardDeviceStats] No devices with stats data found");
           // Still set the first device so we can show which device we checked
+          if (!isMounted) return;
           setDevice(devices[0]);
           setData([]);
         }
       } catch (e) {
+        if (abortController.signal.aborted) return;
         console.error("Failed to load device stats for dashboard", e);
         if (e instanceof Error) {
           console.error("Error details:", e.message, e.stack);
         }
+        if (!isMounted) return;
         setData([]);
       } finally {
-        setLoading(false);
+        if (isMounted) {
+          setLoading(false);
+        }
       }
     };
     load();
     // Refresh every minute like the other charts
     const interval = setInterval(load, 60000);
-    return () => clearInterval(interval);
+    return () => {
+      isMounted = false;
+      abortController.abort();
+      clearInterval(interval);
+    };
   }, [token]);
 
   if (loading) {

--- a/ui/ui/src/components/dashboard/NetworkThroughputChart.tsx
+++ b/ui/ui/src/components/dashboard/NetworkThroughputChart.tsx
@@ -1,0 +1,426 @@
+"use client";
+
+import { useEffect, useState, useMemo } from "react";
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ChartContainer, ChartTooltip } from "@/components/ui/chart";
+import { useAuth } from "@/context/authContext";
+import { fetchPortStatsAggregate } from "@/lib/portUtilization";
+import { useLanguage } from "@/context/languageContext";
+import { AggregateTimeSeriesPoint } from "@/lib/types";
+import { TrendingUp, TrendingDown } from "lucide-react";
+
+type TimeRange = "5min" | "1hour" | "24hour" | "7days";
+
+interface NetworkThroughputChartProps {
+  timeRange: TimeRange;
+}
+
+export default function NetworkThroughputChart({
+  timeRange,
+}: NetworkThroughputChartProps) {
+  const { token } = useAuth();
+  const { getT } = useLanguage();
+  const [data, setData] = useState<AggregateTimeSeriesPoint[]>([]);
+  const [previousPeriodTotal, setPreviousPeriodTotal] = useState<number | null>(null);
+  const [isLoadingTrend, setIsLoadingTrend] = useState(false);
+
+  // Calculate hours and interval based on time range
+  const getTimeRangeParams = (range: TimeRange) => {
+    switch (range) {
+      case "5min":
+        return { hours: 5 / 60, interval: "10 seconds" };
+      case "1hour":
+        return { hours: 1, interval: "1 minute" };
+      case "24hour":
+        return { hours: 24, interval: "5 minutes" };
+      case "7days":
+        return { hours: 168, interval: "1 hour" };
+      default:
+        return { hours: 1, interval: "1 minute" };
+    }
+  };
+
+  // Calculate metrics from chart data
+  const metrics = useMemo(() => {
+    if (data.length === 0) {
+      return {
+        peak: 0,
+        totalTransferred: 0,
+      };
+    }
+
+    // Group by timestamp and sum throughputs (same logic as chart)
+    const timeMap = new Map<number, number>();
+    data.forEach((point) => {
+      const ts = new Date(point.bucket_time).getTime();
+      const throughput = point.avg_throughput ?? 0;
+      timeMap.set(ts, (timeMap.get(ts) || 0) + throughput);
+    });
+
+    const aggregatedData = Array.from(timeMap.entries())
+      .map(([ts, throughput]) => ({ ts, throughput }))
+      .sort((a, b) => a.ts - b.ts);
+
+    if (aggregatedData.length === 0) {
+      return {
+        peak: 0,
+        totalTransferred: 0,
+      };
+    }
+
+    // Peak throughput
+    const peak = Math.max(...aggregatedData.map((d) => d.throughput));
+
+    // Calculate total data transferred (sum of throughput * time interval)
+    const { interval } = getTimeRangeParams(timeRange);
+    let intervalSeconds = 60; // default 1 minute
+    if (interval.includes("second")) {
+      intervalSeconds = parseInt(interval.match(/\d+/)?.[0] || "10") || 10;
+    } else if (interval.includes("minute")) {
+      intervalSeconds = (parseInt(interval.match(/\d+/)?.[0] || "1") || 1) * 60;
+    } else if (interval.includes("hour")) {
+      intervalSeconds = (parseInt(interval.match(/\d+/)?.[0] || "1") || 1) * 3600;
+    }
+
+    // Sum throughput * interval to get total bytes
+    // Throughput is in Mbps, convert to bytes: Mbps * 125000 bytes/sec * seconds
+    const totalBytes = aggregatedData.reduce(
+      (sum, d) => sum + (d.throughput * 125000 * intervalSeconds),
+      0
+    );
+
+    return {
+      peak,
+      totalTransferred: totalBytes,
+    };
+  }, [data, timeRange]);
+
+  // Get time period label for trend text
+  const getTimePeriodLabel = (range: TimeRange): string => {
+    switch (range) {
+      case "5min":
+        return "last 5 minutes";
+      case "1hour":
+        return "last hour";
+      case "24hour":
+        return "last 24 hours";
+      case "7days":
+        return "last 7 days";
+      default:
+        return "last hour";
+    }
+  };
+
+  // Calculate trend percentage
+  const trend = useMemo(() => {
+    if (!previousPeriodTotal || metrics.totalTransferred === 0 || previousPeriodTotal === 0) {
+      return null;
+    }
+
+    const change = ((metrics.totalTransferred - previousPeriodTotal) / previousPeriodTotal) * 100;
+    return {
+      percentage: Math.abs(change),
+      isPositive: change >= 0,
+    };
+  }, [metrics.totalTransferred, previousPeriodTotal]);
+
+  // Format bytes to human-readable format
+  const formatBytes = (bytes: number): string => {
+    const units = ["B", "KB", "MB", "GB", "TB", "PB"];
+    let size = bytes;
+    let unitIndex = 0;
+    while (size >= 1024 && unitIndex < units.length - 1) {
+      size /= 1024;
+      unitIndex++;
+    }
+    return `${size.toFixed(1)} ${units[unitIndex]}`;
+  };
+
+  // Format throughput to Kbps/Mbps/Gbps automatically
+  const formatThroughput = (mbps: number): string => {
+    if (mbps >= 1000) {
+      return `${(mbps / 1000).toFixed(1)} Gbps`;
+    } else if (mbps < 1) {
+      return `${(mbps * 1000).toFixed(1)} Kbps`;
+    }
+    return `${mbps.toFixed(1)} Mbps`;
+  };
+
+  // Get the appropriate unit for the Y-axis based on data range
+  const getYAxisUnit = (): { unit: string; formatter: (val: number) => string } => {
+    if (data.length === 0) {
+      return { unit: "Mbps", formatter: (v) => `${v.toFixed(0)}` };
+    }
+
+    // Find max value in aggregated data
+    const timeMap = new Map<number, number>();
+    data.forEach((point) => {
+      const ts = new Date(point.bucket_time).getTime();
+      const throughput = point.avg_throughput ?? 0;
+      timeMap.set(ts, (timeMap.get(ts) || 0) + throughput);
+    });
+    const maxValue = Math.max(...Array.from(timeMap.values()));
+
+    if (maxValue >= 1000) {
+      return {
+        unit: "Gbps",
+        formatter: (v) => `${(v / 1000).toFixed(1)}`,
+      };
+    } else if (maxValue < 1) {
+      return {
+        unit: "Kbps",
+        formatter: (v) => `${(v * 1000).toFixed(0)}`,
+      };
+    }
+    return {
+      unit: "Mbps",
+      formatter: (v) => `${v.toFixed(0)}`,
+    };
+  };
+
+  const yAxisConfig = getYAxisUnit();
+
+  useEffect(() => {
+    if (!token) return;
+    
+    // Reset previous period total when time range changes to prevent flickering
+    setPreviousPeriodTotal(null);
+    setIsLoadingTrend(true);
+    
+    const load = async () => {
+      try {
+        const { hours, interval } = getTimeRangeParams(timeRange);
+        
+        // Fetch both current and previous period data in parallel
+        const [currentRes, previousRes] = await Promise.all([
+          fetchPortStatsAggregate(token, null, hours, interval),
+          fetchPortStatsAggregate(token, null, hours * 2, interval).catch(() => null),
+        ]);
+        
+        if (currentRes && currentRes.aggregated_data) {
+          console.log("[NetworkThroughputChart] Received data:", currentRes.aggregated_data.length, "points");
+          setData(currentRes.aggregated_data);
+          
+          // Calculate interval seconds
+          let intervalSeconds = 60;
+          if (interval.includes("second")) {
+            intervalSeconds = parseInt(interval.match(/\d+/)?.[0] || "10") || 10;
+          } else if (interval.includes("minute")) {
+            intervalSeconds = (parseInt(interval.match(/\d+/)?.[0] || "1") || 1) * 60;
+          } else if (interval.includes("hour")) {
+            intervalSeconds = (parseInt(interval.match(/\d+/)?.[0] || "1") || 1) * 3600;
+          }
+          
+          // Calculate previous period total if we have the data
+          if (previousRes && previousRes.aggregated_data) {
+            const allData = previousRes.aggregated_data;
+            const sortedByTime = [...allData].sort(
+              (a, b) => new Date(a.bucket_time).getTime() - new Date(b.bucket_time).getTime()
+            );
+            
+            if (sortedByTime.length > 0) {
+              const midpoint = sortedByTime[Math.floor(sortedByTime.length / 2)];
+              const midpointTime = new Date(midpoint.bucket_time).getTime();
+              
+              // Get previous period data (first half)
+              const previousPeriodData = sortedByTime.filter(
+                (point) => new Date(point.bucket_time).getTime() < midpointTime
+              );
+              
+              const prevTimeMap = new Map<number, number>();
+              previousPeriodData.forEach((point) => {
+                const ts = new Date(point.bucket_time).getTime();
+                const throughput = point.avg_throughput ?? 0;
+                prevTimeMap.set(ts, (prevTimeMap.get(ts) || 0) + throughput);
+              });
+              
+              const previousTotal = Array.from(prevTimeMap.values()).reduce(
+                (sum, throughput) => sum + (throughput * 125000 * intervalSeconds),
+                0
+              );
+              
+              // Set both values together to prevent flickering
+              setPreviousPeriodTotal(previousTotal);
+              setIsLoadingTrend(false);
+            } else {
+              setPreviousPeriodTotal(null);
+              setIsLoadingTrend(false);
+            }
+          } else {
+            setPreviousPeriodTotal(null);
+            setIsLoadingTrend(false);
+          }
+        } else {
+          console.warn("[NetworkThroughputChart] No data in response:", currentRes);
+          setData([]);
+          setPreviousPeriodTotal(null);
+          setIsLoadingTrend(false);
+        }
+      } catch (error) {
+        console.error("[NetworkThroughputChart] Error fetching data:", error);
+        setData([]);
+        setPreviousPeriodTotal(null);
+        setIsLoadingTrend(false);
+      }
+    };
+    load();
+    // Refresh interval based on time range (shorter for shorter ranges)
+    const refreshInterval = timeRange === "5min" ? 30000 : timeRange === "1hour" ? 60000 : 300000; // 30s, 1min, or 5min
+    const interval = setInterval(load, refreshInterval);
+    return () => clearInterval(interval);
+  }, [token, timeRange]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          {getT(
+            "dashboard.throughput",
+            "Total Network Throughput (Port Utilization)"
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {data.length === 0 ? (
+            <div className="flex items-center justify-center h-[300px] text-muted-foreground">
+                No throughput data available.
+            </div>
+        ) : (
+        <>
+          {/* Summary Metrics */}
+          <div className="mb-6 grid grid-cols-2 gap-4">
+            {/* Total Data Transferred */}
+            <div>
+              <div className="text-sm text-muted-foreground">
+                Total Data Transferred
+              </div>
+              <div className="text-2xl font-semibold text-[#a855f7]">
+                {formatBytes(metrics.totalTransferred)}
+              </div>
+              {!isLoadingTrend && trend !== null && (
+                <div
+                  className={`flex items-center gap-1 text-sm mt-1 ${
+                    trend.isPositive ? "text-green-500" : "text-red-500"
+                  }`}
+                >
+                  {trend.isPositive ? (
+                    <TrendingUp className="h-4 w-4" />
+                  ) : (
+                    <TrendingDown className="h-4 w-4" />
+                  )}
+                  <span className="text-muted-foreground">
+                    {trend.isPositive ? "+" : "-"}
+                    {trend.percentage.toFixed(1)}% from {getTimePeriodLabel(timeRange)}
+                  </span>
+                </div>
+              )}
+            </div>
+
+            {/* Peak Throughput */}
+            <div>
+              <div className="text-sm text-muted-foreground">Peak</div>
+              <div className="text-2xl font-semibold">
+                {formatThroughput(metrics.peak)}
+              </div>
+            </div>
+          </div>
+          <ChartContainer
+          config={{
+            throughput: { label: "Mbps", color: "#a855f7" },
+          }}
+          className="h-[300px] w-full"
+        >
+          <AreaChart
+            accessibilityLayer
+            data={(() => {
+              // Group by timestamp and sum all port throughputs to get network total
+              const timeMap = new Map<number, number>();
+              data.forEach((point) => {
+                const ts = new Date(point.bucket_time).getTime();
+                const throughput = point.avg_throughput ?? 0;
+                timeMap.set(ts, (timeMap.get(ts) || 0) + throughput);
+              });
+              
+              return Array.from(timeMap.entries())
+                .map(([ts, throughput]) => ({ ts, throughput }))
+                .sort((a, b) => a.ts - b.ts);
+            })()}
+            margin={{
+              left: 12,
+              right: 12,
+            }}
+          >
+            <defs>
+              <linearGradient id="fillThroughput" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#a855f7" stopOpacity={0.8} />
+                <stop offset="95%" stopColor="#a855f7" stopOpacity={0.1} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid vertical={false} />
+            <XAxis
+              dataKey="ts"
+              type="number"
+              scale="time"
+              domain={["dataMin", "dataMax"]}
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+              minTickGap={80}
+              tickFormatter={(v) =>
+                new Date(v).toLocaleTimeString([], {
+                  hour: "2-digit",
+                  minute: "2-digit",
+                })
+              }
+            />
+            <YAxis
+              tickLine={false}
+              axisLine={false}
+              label={{
+                value: yAxisConfig.unit,
+                angle: -90,
+                position: "insideLeft",
+              }}
+              tickFormatter={yAxisConfig.formatter}
+            />
+            <ChartTooltip
+              cursor={false}
+              content={({ active, payload }) => {
+                if (!active || !payload?.length) return null;
+                const value = payload[0]?.value;
+                const ts = payload[0]?.payload?.ts;
+                const throughputValue = typeof value === "number" ? value : 0;
+                return (
+                  <div className="rounded-lg border bg-background p-2 shadow-sm">
+                    <p className="text-sm font-medium mb-2">
+                      {ts ? new Date(ts).toLocaleString() : ""}
+                    </p>
+                    <div className="grid grid-cols-2 gap-2">
+                      <span className="font-medium">Throughput:</span>
+                      <span className="font-mono">
+                        {formatThroughput(throughputValue)}
+                      </span>
+                    </div>
+                  </div>
+                );
+              }}
+            />
+            <Area
+              dataKey="throughput"
+              type="monotone"
+              strokeWidth={2}
+              stroke="#a855f7"
+              fill="url(#fillThroughput)"
+              fillOpacity={0.4}
+              isAnimationActive={false}
+            />
+          </AreaChart>
+        </ChartContainer>
+        </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/ui/ui/src/components/dashboard/UserActivityChart.tsx
+++ b/ui/ui/src/components/dashboard/UserActivityChart.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Bar, BarChart, XAxis, YAxis, LabelList } from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ChartContainer, ChartTooltip } from "@/components/ui/chart";
+import { useAuth } from "@/context/authContext";
+import { fetchAggregateFlowsByUser } from "@/lib/networkData";
+
+interface UserActivityData {
+  name: string;
+  value: number;
+}
+
+type TimeRange = "5min" | "1hour" | "24hour" | "7days";
+
+interface UserActivityChartProps {
+  timeRange: TimeRange;
+}
+
+export default function UserActivityChart({
+  timeRange,
+}: UserActivityChartProps) {
+  const { token } = useAuth();
+  const [data, setData] = useState<UserActivityData[]>([]);
+
+  // Convert time range to period string for API
+  const getPeriodString = (range: TimeRange): string => {
+    switch (range) {
+      case "5min":
+        return "5 minutes";
+      case "1hour":
+        return "1 hour";
+      case "24hour":
+        return "24 hours";
+      case "7days":
+        return "7 days";
+      default:
+        return "1 hour";
+    }
+  };
+
+  // Format bytes to human-readable format (KB, MB, GB, TB)
+  const formatBytes = (mb: number): string => {
+    // Convert MB to bytes first
+    const bytes = mb * 1024 * 1024;
+    const units = ["B", "KB", "MB", "GB", "TB", "PB"];
+    let size = bytes;
+    let unitIndex = 0;
+    while (size >= 1024 && unitIndex < units.length - 1) {
+      size /= 1024;
+      unitIndex++;
+    }
+    return `${size.toFixed(1)} ${units[unitIndex]}`;
+  };
+
+  // Get the appropriate unit for the Y-axis based on data range
+  const getYAxisUnit = (): { unit: string; formatter: (val: number) => string } => {
+    if (data.length === 0) {
+      return { unit: "MB", formatter: (v) => `${v.toFixed(0)}` };
+    }
+
+    // Find max value in data
+    const maxValue = Math.max(...data.map((d) => d.value));
+
+    // Convert MB to bytes to determine appropriate unit
+    const maxBytes = maxValue * 1024 * 1024;
+
+    if (maxBytes >= 1024 * 1024 * 1024 * 1024) {
+      // TB
+      return {
+        unit: "TB",
+        formatter: (v) => `${(v / (1024 * 1024)).toFixed(1)}`,
+      };
+    } else if (maxBytes >= 1024 * 1024 * 1024) {
+      // GB
+      return {
+        unit: "GB",
+        formatter: (v) => `${(v / 1024).toFixed(1)}`,
+      };
+    } else if (maxBytes >= 1024 * 1024) {
+      // MB (current)
+      return {
+        unit: "MB",
+        formatter: (v) => `${v.toFixed(0)}`,
+      };
+    } else if (maxBytes >= 1024) {
+      // KB
+      return {
+        unit: "KB",
+        formatter: (v) => `${(v * 1024).toFixed(0)}`,
+      };
+    }
+    // Bytes
+    return {
+      unit: "B",
+      formatter: (v) => `${(v * 1024 * 1024).toFixed(0)}`,
+    };
+  };
+
+  const yAxisConfig = getYAxisUnit();
+
+  useEffect(() => {
+    if (!token) return;
+    const load = async () => {
+      const period = getPeriodString(timeRange);
+      const res = await fetchAggregateFlowsByUser(token, period);
+      // Transform { mac: bytes } -> [{ name: mac, value: mb }]
+      const sorted = Object.entries(res)
+        .map(([mac, bytes]) => ({
+          name: mac,
+          value: Number((bytes / 1024 / 1024).toFixed(2)), // MB
+        }))
+        .sort((a, b) => b.value - a.value);
+        // .slice(0, 5); // Removed slice to show all users
+      setData(sorted);
+    };
+    load();
+    // Refresh interval based on time range
+    const refreshInterval =
+      timeRange === "5min"
+        ? 30000 // 30 seconds
+        : timeRange === "1hour"
+        ? 60000 // 1 minute
+        : timeRange === "24hour"
+        ? 300000 // 5 minutes
+        : 600000; // 10 minutes for 7 days
+    const interval = setInterval(load, refreshInterval);
+    return () => clearInterval(interval);
+  }, [token, timeRange]);
+
+  // Get top user (first in sorted array)
+  const topUser = data.length > 0 ? data[0] : null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>User Data Consumption</CardTitle>
+        {topUser && (
+          <div className="mt-4 space-y-1">
+            <div className="flex items-baseline gap-2">
+              <span className="text-sm font-semibold">Top User:</span>
+              <span className="text-base font-bold">{topUser.name}</span>
+            </div>
+            <div className="text-sm text-muted-foreground">
+              {formatBytes(topUser.value)} Consumed
+            </div>
+          </div>
+        )}
+      </CardHeader>
+      <CardContent>
+        {data.length === 0 ? (
+            <div className="flex items-center justify-center h-[300px] text-muted-foreground">
+                No user activity data available for the selected time range.
+            </div>
+        ) : (
+        <ChartContainer
+          config={{ value: { label: yAxisConfig.unit, color: "#a855f7" } }}
+          className="h-[300px] w-full"
+        >
+          <BarChart data={data} layout="vertical" margin={{ left: 20 }}>
+            <XAxis 
+              type="number" 
+              hide
+              tickFormatter={yAxisConfig.formatter}
+            />
+            <YAxis
+              dataKey="name"
+              type="category"
+              width={120}
+              tick={{ fontSize: 12 }}
+            />
+            <ChartTooltip
+              content={({ active, payload }) => {
+                if (!active || !payload?.length) return null;
+                const data = payload[0];
+                const value = data.value as number;
+                const name = data.payload?.name as string;
+                return (
+                  <div className="rounded-lg border bg-background p-2 shadow-sm">
+                    <p className="text-sm font-medium mb-2">{name || "Unknown"}</p>
+                    <div className="grid grid-cols-2 gap-2">
+                      <span className="font-medium">Data:</span>
+                      <span className="font-mono">
+                        {formatBytes(value)}
+                      </span>
+                    </div>
+                  </div>
+                );
+              }}
+            />
+            <Bar dataKey="value" fill="#a855f7" radius={4}>
+              <LabelList
+                dataKey="value"
+                position="right"
+                formatter={(v: number) => formatBytes(v)}
+              />
+            </Bar>
+          </BarChart>
+        </ChartContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/ui/ui/src/components/graphs/port-utilization/PortUtilizationChart.tsx
+++ b/ui/ui/src/components/graphs/port-utilization/PortUtilizationChart.tsx
@@ -85,14 +85,12 @@ export function PortUtilizationChart({
     // Cap at 100% to handle API edge cases (backend already returns percentages)
     // Handle null values from backend (when link_speed is unknown)
     dataPoint[`${portKey}_utilization`] =
-      point.avg_utilization !== null
+      point.avg_utilization != null
         ? Math.min(point.avg_utilization, 100)
         : null;
     dataPoint[`${portKey}_throughput`] = point.avg_throughput ?? null;
     dataPoint[`${portKey}_max_utilization`] =
-      point.max_utilization !== null
-        ? Math.min(point.max_utilization, 100)
-        : null;
+      point.max_utilization != null ? Math.min(point.max_utilization, 100) : null;
   });
 
   const chartData = Array.from(timeMap.values()).sort(

--- a/ui/ui/src/lib/types.ts
+++ b/ui/ui/src/lib/types.ts
@@ -1156,12 +1156,13 @@ export interface ByPortResponse {
 // Aggregate endpoint time series point
 export interface AggregateTimeSeriesPoint {
   bucket_time: string;
-  ip_address: string;
-  port_name: string;
-  avg_utilization: number | null;
-  max_utilization: number | null;
-  avg_throughput: number | null;
-  max_throughput: number | null;
+  ip_address?: string;
+  port_name?: string;
+  avg_utilization?: number | null;
+  max_utilization?: number | null;
+  avg_throughput?: number | null;
+  max_throughput?: number | null;
+  total_throughput?: number | null; // For network-wide aggregation
 }
 
 // Aggregate endpoint response


### PR DESCRIPTION
- add the throughput, user consumption, and device stats cards to /dashboard
- style the charts to match the device overview visuals and auto-scale units (Kbps ↔ Gbps, KB ↔ TB)
- introduce a shared time-range selector plus headline metrics (total transferred, peak, top user)
- compute trend percentages by comparing the selected period with the previous period, and render arrows + percentages
- improve resilience: graceful empty states, sequential device fallback for stats, and better tooltips/logging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Network Overview dashboard with selectable time ranges (5min, 1hour, 24hour, 7days)
  * Network throughput chart showing total data transferred, peak, and trend vs. prior period
  * User activity chart showing per-user consumption with top-user summary
  * Device statistics card that auto-discovers monitored devices and refreshes periodically

* **Improvements**
  * More resilient data handling, graceful empty/loading states, and improved error handling across dashboard charts

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->